### PR TITLE
Allow to set max number of concurrent downloads

### DIFF
--- a/src/tikorgzo/args_handler.py
+++ b/src/tikorgzo/args_handler.py
@@ -27,6 +27,11 @@ class ArgsHandler:
             help="A text file containing links"
         )
         self._parser.add_argument(
+            "--max-concurrent-downloads",
+            type=int,
+            help="Set the maximum number of concurrent downloads (default: 4)"
+        )
+        self._parser.add_argument(
             "-v",
             help="Show the app's version",
             action="version",

--- a/src/tikorgzo/core/download_manager/downloader.py
+++ b/src/tikorgzo/core/download_manager/downloader.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional
 import aiofiles
 import aiohttp
 from rich.progress import Progress
@@ -8,8 +9,8 @@ from tikorgzo.core.video.model import Video
 
 
 class Downloader:
-    def __init__(self) -> None:
-        self.semaphore = asyncio.Semaphore(5)
+    def __init__(self, max_concurrent_downloads: Optional[int] = None) -> None:
+        self.semaphore = asyncio.Semaphore(4) if max_concurrent_downloads is None else asyncio.Semaphore(max_concurrent_downloads)
 
     async def __aenter__(self) -> 'Downloader':
         self.session = aiohttp.ClientSession()

--- a/src/tikorgzo/core/functions.py
+++ b/src/tikorgzo/core/functions.py
@@ -1,6 +1,6 @@
 import asyncio
 import os
-from typing import List
+from typing import List, Optional
 from rich.progress import Progress, BarColumn, TextColumn, DownloadColumn, TransferSpeedColumn, TimeRemainingColumn
 
 from tikorgzo.console import console
@@ -19,7 +19,10 @@ async def extract_download_link(videos: List[Video]) -> List[Video]:
     return videos
 
 
-async def download_video(videos: list[Video]) -> list[Video]:
+async def download_video(
+    max_concurrent_downloads: Optional[int],
+    videos: list[Video]
+) -> list[Video]:
     """Download all the videos from queue that has the list of Video instances."""
 
     with Progress(
@@ -29,7 +32,7 @@ async def download_video(videos: list[Video]) -> list[Video]:
         TransferSpeedColumn(),
         TimeRemainingColumn(),
     ) as progress_displayer:
-        async with Downloader() as downloader:
+        async with Downloader(max_concurrent_downloads) as downloader:
             download_tasks = [downloader.download(video, progress_displayer) for video in videos]
             try:
                 await asyncio.gather(*download_tasks)

--- a/src/tikorgzo/main.py
+++ b/src/tikorgzo/main.py
@@ -79,7 +79,7 @@ async def main():
     console.print("\n[b]Stage 3/3[/b]: Download")
     console.print(f"Downloading {download_queue.total()} videos...")
 
-    videos = await fn.download_video(download_queue.get_queue())
+    videos = await fn.download_video(args.max_concurrent_downloads, download_queue.get_queue())
     fn.cleanup_interrupted_downloads(videos)
     fn.print_download_results(videos)
 

--- a/src/tikorgzo/main.py
+++ b/src/tikorgzo/main.py
@@ -1,4 +1,5 @@
 import asyncio
+import sys
 from playwright.sync_api import Error as PlaywrightError
 
 from tikorgzo import exceptions as exc
@@ -19,6 +20,10 @@ async def main():
     if not args.file and not args.link:
         ah._parser.print_help()
         exit(0)
+
+    if args.max_concurrent_downloads > 16 or args.max_concurrent_downloads < 1:
+        console.print("[red]error[/red]: '[blue]--max-concurrent-downloads[/blue]' must be in the range of 1 to 16.")
+        sys.exit(1)
 
     # Get the video IDs
     video_links = video_link_extractor(args.file, args.link)


### PR DESCRIPTION
Allows user how many videos they can download at a time. If not set, 4 downloads are allowed to be downloaded concurrently.

Resolves #10 