### PR TITLE
Allow strict duplicate download checking

### DIFF
--- a/src/tikorgzo/cli/args_handler.py
+++ b/src/tikorgzo/cli/args_handler.py
@@ -36,6 +36,12 @@ class ArgsHandler:
             help="Set a customized filename for the downloaded video"
         )
         self._parser.add_argument(
+            "--strict-duplicate-check",
+            help="Enable strict duplicate checking based on video ID of filename",
+            action="store_true",
+            default=None
+        )
+        self._parser.add_argument(
             "-v",
             help="Show the app's version",
             action="version",

--- a/src/tikorgzo/cli/workflow.py
+++ b/src/tikorgzo/cli/workflow.py
@@ -29,7 +29,7 @@ async def main():
             curr_pos = idx + 1
             with console.status(f"Checking video {curr_pos} if already exist..."):
                 try:
-                    video = Video(video_link=video_link, filename_template=args.filename_template)
+                    video = Video(video_link=video_link, filename_template=args.filename_template, strict_duplicate_check=args.strict_duplicate_check)
                     video.download_status = DownloadStatus.QUEUED
                     download_queue.add(video)
                     console.print(f"Added video {curr_pos} ({video.video_id}) to download queue.")

--- a/src/tikorgzo/core/video/model.py
+++ b/src/tikorgzo/core/video/model.py
@@ -36,22 +36,27 @@ class Video:
     Args:
         video_link (str): The TikTok video link or video ID.
         filename_template (Optional[str]): Template for naming the output file.
+        strict_duplicate_check (Optional[bool]):
 
     Raises:
         InvalidVideoLink: If the provided video link is not valid.
         VideoFileAlreadyExistsError: If the video file already exists in the output directory.
     """
 
-    def __init__(self, video_link: str, filename_template: Optional[str] = None):
-        video_link = processor.validate_video_link(video_link)
-
+    def __init__(
+        self,
+        video_link: str,
+        filename_template: Optional[str] = None,
+        strict_duplicate_check: Optional[str] = None
+    ):
+        self._video_link = processor.validate_video_link(video_link)
         self._video_id: int = processor.extract_video_id(video_link)
 
-        processor.check_if_already_downloaded(video_link)
+        if strict_duplicate_check:
+            processor.check_if_already_downloaded(self._video_id)
 
         self._username: Optional[str] = processor._process_username(video_link)
         self._date: datetime = processor.get_date(self._video_id)
-        self._video_link: str = video_link
         self._download_link: Optional[str] = None
         self._file_size: Optional[FileSize] = None
         self._download_status: Optional[DownloadStatus] = None

--- a/src/tikorgzo/core/video/processor.py
+++ b/src/tikorgzo/core/video/processor.py
@@ -51,18 +51,19 @@ class VideoInfoProcessor:
 
         raise VideoIDExtractionError()
 
-    def check_if_already_downloaded(self, filename: str):
+    def check_if_already_downloaded(self, video_id: int):
         """Recursively checks the output folder, which is the default DOWNLOAD_PATH,
-        to see if a file (where the filename is a video ID) already exists. If true,
-        this will raise an error."""
+        to see if a file already exists whether the filename contains the video ID or not. 
+        If true, this will raise an error.
 
-        filename += ".mp4"
+        This function is only run when `--strict-duplicate-check` is enabled.
+        """
 
         for root, _, filenames in os.walk(DOWNLOAD_PATH):
             for f in filenames:
-                if f == filename:
+                if str(video_id) in f:
                     username = os.path.basename(root)
-                    raise VideoFileAlreadyExistsError(filename, username)
+                    raise VideoFileAlreadyExistsError(f, username)
 
     def get_date(self, video_id: int):
         """Gets the date from the video ID.
@@ -107,6 +108,7 @@ class VideoInfoProcessor:
             video_file = os.path.join(output_path, video_filename)
 
             if os.path.exists(video_file):
+                print("-----------------")
                 raise VideoFileAlreadyExistsError(video_filename, username)
 
             video._output_file_dir = output_path


### PR DESCRIPTION
This checks the downloaded video's filename if it contains video ID on it. To use this, just supply `--strict-duplicate-check` in the command-line